### PR TITLE
WIP/Placeholder : Rename SwiftPM package to SauceMobileBeta for Backtrace coexistence

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,19 +2,36 @@
 
 import PackageDescription
 
+// TODO(release): update documentation
+// Sauce Mobile Beta SDK (formerly TestFairy SDK).
+//
+// Package/product are renamed to SauceMobileBeta,
+// the binary module remains "TestFairy" so existing source/integrations keeps working unchanged:
+//
+//     import TestFairy
+//     TestFairy.beginWithoutCrashHandler("<token>")
+//
+// This package must point at the CRASHLESS .xcframework (Backtrace coexistence artifact).
+// The artifact must pass tools/ci/validate-ios-crashless.sh before the url/checksum below are updated for a release. Backtrace owns crashes.
 let package = Package(
-    name: "TestFairy",
+    name: "SauceMobileBeta",
+    platforms: [
+        .iOS(.v11)
+    ],
     products: [
         .library(
-            name: "TestFairy",
+            name: "SauceMobileBeta",
             targets: ["TestFairy"]
         ),
     ],
     targets: [
         .binaryTarget(
             name: "TestFairy",
-            url: "https://testfairy.s3.amazonaws.com/sdk/TestFairySDK-1.33.1.xcframework.zip",
-            checksum: "e6e9f8d7295d53c69f22758188c4417b827cf768172cbd77f269a39562e52029"
+            // TODO(release): replace with the published crashless artifact URL + checksum.
+            // Produce with `make dist/xcframework-crashless` and compute the
+            // checksum via `swift package compute-checksum <zip>`.
+            url: "https://saucelabs-mobile-sdk.s3.amazonaws.com/sdk/SauceMobileBeta-<version>.xcframework.zip",
+            checksum: "<sha256-of-crashless-xcframework-zip>"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,12 +1,39 @@
-# Swift Package for TestFairy on iOS
+# Swift Package for Sauce Mobile Beta on iOS
 
-For class reference, installation and more information, please visit
-[Integrating the iOS SDK](https://docs.testfairy.com/iOS_SDK/Integrating_iOS_SDK.html) by TestFairy.
+Sauce Mobile Beta SDK, formerly TestFairy SDK.
+
+This Swift package distributes the **crashless** Sauce Mobile Beta artifact,
+intended for use alongside **Backtrace Error Reporting SDK**. Backtrace is the sole crash owner.
+This SDK provides beta session, feedback, remote logging, and tester workflow features.
+
+## Installation
+
+Add the package to your project:
+
+```
+https://github.com/saucelabs/sauce-mobile-beta-ios.git
+```
+
+The SwiftPM product is `SauceMobileBeta`. 
+The runtime module is still `TestFairy`, so existing source keeps working unchanged.
+
+## Usage with Backtrace
+
+```swift
+import Backtrace
+import TestFairy
+
+// 1. Initialize Backtrace as the crash owner.
+// 2. Initialize Sauce Mobile Beta WITHOUT a crash handler.
+TestFairy.beginWithoutCrashHandler("<sauce-mobile-beta-token>")
+```
+
+Do not call `enableCrashHandler` / `installCrashHandler` in coexistence mode, they are no-ops in this crashless artifact.
 
 License
 =======
 
-    Copyright 2017-2021 TestFairy.
+    Copyright 2017-2026 Sauce Labs Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Rename SwiftPM package to SauceMobileBeta for Backtrace coexistence

- Package/product become SauceMobileBeta; the binary target/module stays "TestFairy" so consumers keep `import TestFairy`. 
- Add platforms: [.iOS(.v11)].
- The binaryTarget should point at the crashless xcframework.
- README updated for the rename and beginWithoutCrashHandler usage.
- TODOs : URL and checksum are release / documentation update.



